### PR TITLE
clean up sort when using count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.6 (2024-07-19)
+
+### Changes
+
+* Reset sort when using `find-cursor.count` due to internal code using projection with `{ _id: 1 }`.
+
 ## 1.0.5 (2024-07-09)
 
 ### Add

--- a/find-cursor.js
+++ b/find-cursor.js
@@ -12,7 +12,12 @@ module.exports = function (baseClass) {
       options = typeof options !== 'function' ? options : undefined;
 
       return wrapMaybeCallback(
-        this.project({ _id: 1 }).toArray().then(count => count.length),
+        this
+          .clone()
+          .project({ _id: 1 })
+          .sort(null)
+          .toArray()
+          .then(count => count.length),
         callback
       );
     }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Reset sort when calling cursor count

## What are the specific steps to test this change?

The issue only appears with MongoDB server 3.x.

1. Perform a search in apostrophe with this version of `@apostrophecms/emulate-mongo-3-driver`
2. You should see the result page

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
